### PR TITLE
adds flexibility to wheel styling

### DIFF
--- a/packages/color-wheel/src/index.tsx
+++ b/packages/color-wheel/src/index.tsx
@@ -59,10 +59,10 @@ const Wheel = React.forwardRef<HTMLDivElement, WheelProps>((props, ref) => {
       className={[prefixCls, className || ''].filter(Boolean).join(' ')}
       {...other}
       style={{
-        ...style,
         position: 'relative',
         width,
         height,
+        ...style,
       }}
       ref={ref}
       onMove={handleChange}


### PR DESCRIPTION
In the current wheel implementation the `height` and `width` can only be set to numbers and can't be overridden by the style prop. Similarly, the `position` can't be overridden.

This PR moves the style prop spread operation after `height`, `width`, and `position` so that they can be overridden by the style prop if needed. 