### PR TITLE
fix: avoid star exporting react components

### DIFF
--- a/packages/color/src/index.tsx
+++ b/packages/color/src/index.tsx
@@ -1,22 +1,4 @@
 export * from '@uiw/color-convert';
-export * from '@uiw/react-color-alpha';
-export * from '@uiw/react-color-compact';
-export * from '@uiw/react-color-chrome';
-export * from '@uiw/react-color-colorful';
-export * from '@uiw/react-color-circle';
-export * from '@uiw/react-color-block';
-export * from '@uiw/react-color-editable-input';
-export * from '@uiw/react-color-editable-input-rgba';
-export * from '@uiw/react-color-editable-input-hsla';
-export * from '@uiw/react-color-hue';
-export * from '@uiw/react-color-github';
-export * from '@uiw/react-color-material';
-export * from '@uiw/react-color-saturation';
-export * from '@uiw/react-color-shade-slider';
-export * from '@uiw/react-color-sketch';
-export * from '@uiw/react-color-slider';
-export * from '@uiw/react-color-swatch';
-export * from '@uiw/react-color-wheel';
 
 export { default as Alpha } from '@uiw/react-color-alpha';
 export { default as Block } from '@uiw/react-color-block';


### PR DESCRIPTION
Fixes #104.

The CommonJS build is currently broken due to a duplicate export with the name `render`. Any project which currently imports the CommonJS build will get an `Uncaught TypeError: Cannot redefine property: render` error.

The reason for this is because all of the sub packages are star exported from the main entrypoint, which results in multiple exports with the name `render`.

You can confirm this problem by creating the following simple CommonJS file, and seeing the error.

```js
const reactColor = require("@uiw/react-color");
console.log(reactColor);
// Uncaught TypeError: Cannot redefine property: render
```

When the entrypoint compiles down to CommonJS, it ends up like this. Each of these Object.keys blocks is looping over all the exports from the sub package, and attaching them to exports using Object.defineProperty.

```js
var _reactColorSwatch = _interopRequireWildcard(require("@uiw/react-color-swatch"));
Object.keys(_reactColorSwatch).forEach(function (key) {
  if (key === "default" || key === "__esModule") return;
  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
  if (key in exports && exports[key] === _reactColorSwatch[key]) return;
  Object.defineProperty(exports, key, {
    enumerable: true,
    get: function get() {
      return _reactColorSwatch[key];
    }
  });
});
var _reactColorWheel = _interopRequireWildcard(require("@uiw/react-color-wheel"));
Object.keys(_reactColorWheel).forEach(function (key) {
  if (key === "default" || key === "__esModule") return;
  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
  if (key in exports && exports[key] === _reactColorWheel[key]) return;
  Object.defineProperty(exports, key, {
    enumerable: true,
    get: function get() {
      return _reactColorWheel[key];
    }
  });
});
```

You cannot use Object.defineProperty to redefine an existing property. So the first block defines a render property on exports, and then subsequent packages try to set the same property, causing the error.

I note that in the documentation, all the React components are imported via their name anyway, so these star exports are not needed, apart from `@uiw/color-convert` which contains utility functions.

By removing the star exports, we no longer get `render` directly exported multiple times in the CommonJS file, and the problem is fixed.