### PR TITLE
fix(deps): add missing @uiw/react-color-name to root package

### DIFF
--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -61,6 +61,7 @@
     "@uiw/react-color-github": "2.0.7",
     "@uiw/react-color-hue": "2.0.7",
     "@uiw/react-color-material": "2.0.7",
+    "@uiw/react-color-name": "2.0.7",
     "@uiw/react-color-saturation": "2.0.7",
     "@uiw/react-color-shade-slider": "2.0.7",
     "@uiw/react-color-sketch": "2.0.7",


### PR DESCRIPTION
The `@uiw/react-color-name` package dependency was missing from the root package.

For strict package managers like pnpm, this resulted in a `Cannot find module '@uiw/react-color-name'` error when trying to import `@uiw/react-color`.