### PR TITLE
fix: only access window object after app is loaded

### DIFF
--- a/packages/color-chrome/src/EyeDropper.tsx
+++ b/packages/color-chrome/src/EyeDropper.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export const isSupportEyeDropper = 'EyeDropper' in window;
+export function getIsEyeDropperSupported() {
+  return 'EyeDropper' in window;
+}
 
 export interface EyeDropperProps {
   onPickColor?: (color: string) => void;

--- a/packages/color-chrome/src/index.tsx
+++ b/packages/color-chrome/src/index.tsx
@@ -17,7 +17,7 @@ import EditableInputRGBA from '@uiw/react-color-editable-input-rgba';
 import EditableInputHSLA from '@uiw/react-color-editable-input-hsla';
 import { useState } from 'react';
 import Arrow from './Arrow';
-import { EyeDropper, isSupportEyeDropper } from './EyeDropper';
+import { EyeDropper, getIsEyeDropperSupported } from './EyeDropper';
 
 export enum ChromeInputType {
   HEXA = 'hexa',
@@ -111,7 +111,7 @@ const Chrome = React.forwardRef<HTMLDivElement, ChromeProps>((props, ref) => {
             }}
           />
           <div style={{ padding: 15, display: 'flex', alignItems: 'center', gap: 10 }}>
-            {isSupportEyeDropper && showEyeDropper && <EyeDropper onPickColor={handleClickColor} />}
+            {getIsEyeDropperSupported() && showEyeDropper && <EyeDropper onPickColor={handleClickColor} />}
             {showColorPreview && (
               <Alpha
                 width={28}


### PR DESCRIPTION
Fixes issue on start of application when using this library.
Found when using Next.js framework.
`window` is undefined when accessed through global constant, delaying access by wrapping it in a function.

![image](https://github.com/user-attachments/assets/b5c419bf-e5ea-4d8f-82a9-f40f292f37be)
