### PR TITLE
react-color-slider: Added support for Black & White colors, plus new customColorShades prop

### DIFF
--- a/packages/color-slider/src/index.tsx
+++ b/packages/color-slider/src/index.tsx
@@ -3,26 +3,70 @@ import {
   ColorResult,
   color as handleColor,
   hexToHsva,
-  hsvaToHsla,
-  hsvaToHslString,
+  hsvaToRgbaString,
   validHex,
+  hsvaToRgba,
   HsvaColor,
-  hslStringToHsva,
+  rgbaStringToHsva,
 } from '@uiw/color-convert';
 
 export interface SliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'color'> {
   prefixCls?: string;
   color?: string | HsvaColor;
   lightness?: number[];
+  customColorShades?: { color: string | HsvaColor; lightness: number[] }[];
   onChange?: (color: ColorResult, evn: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
+const hsvaCheck = (color?: string | HsvaColor): HsvaColor => {
+  return (typeof color === 'string' && validHex(color) ? hexToHsva(color) : color || {}) as HsvaColor;
+};
+
+const hsvaEqual = (c1: HsvaColor, c2: HsvaColor, lightnessArray?: number[]): boolean => {
+  // Check for exact match of all properties
+  const exactMatch = c1.h === c2.h && c1.s === c2.s && c1.v === c2.v && c1.a === c2.a;
+
+  // If there's an exact match, return true
+  if (exactMatch) return true;
+
+  // If no exact match and a lightness array exists, check if the base
+  // properties match and value is within 1 unit of any lightness value
+  if (lightnessArray) {
+    const baseMatch = c1.h === c2.h && c1.s === c2.s && c1.a === c2.a;
+    return baseMatch && lightnessArray.some((lightness) => Math.abs(c2.v - lightness) <= 1);
+  }
+
+  return false;
+};
+
 const Slider = React.forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
-  const { prefixCls = 'w-color-slider', className, style, onChange, color, lightness = [80, 65, 50, 35, 20], ...other } = props;
-  const hsva = (typeof color === 'string' && validHex(color) ? hexToHsva(color) : color || {}) as HsvaColor;
-  const handleClick = (hslStr: string, evn: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    onChange && onChange(handleColor(hslStringToHsva(hslStr)), evn);
+  const {
+    prefixCls = 'w-color-slider',
+    className,
+    style,
+    onChange,
+    color,
+    customColorShades = [{ color: hexToHsva('#000000'), lightness: [14, 12, 10, 8, 6] }],
+    lightness = [80, 65, 50, 35, 20],
+    ...other
+  } = props;
+  const hsva = hsvaCheck(color);
+
+  // Find matching custom color and its lightness array
+  const matchingCustomColor = customColorShades.find((shade) => {
+    const customHsva = hsvaCheck(shade.color);
+    const isMatch = hsvaEqual(customHsva, hsva, shade.lightness);
+    return isMatch;
+  });
+
+  // Determine which lightness array to use
+  const activeLightness = matchingCustomColor ? matchingCustomColor.lightness : lightness;
+
+  const handleClick = (rgbaStr: string, evn: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const newHsva = rgbaStringToHsva(rgbaStr);
+    onChange && onChange(handleColor(newHsva), evn);
   };
+
   return (
     <div
       ref={ref}
@@ -30,23 +74,24 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
       className={[prefixCls, className || ''].filter(Boolean).join(' ')}
       {...other}
     >
-      {lightness.map((num, idx) => {
-        const hsl = hsvaToHsla(hsva);
-        const hslStr = `hsl(${hsl.h}, 50%, ${num}%)`;
-        const checked = hslStr === hsvaToHslString(hsva);
+      {activeLightness.map((num: number, idx: number) => {
+        const newHsva = { ...hsva, v: num };
+        const rgba = hsvaToRgba(newHsva);
+        const rgbaStr = `rgba(${rgba.r}, ${rgba.g}, ${rgba.b}, ${rgba.a})`;
+        const checked = rgbaStr === hsvaToRgbaString(hsva);
         return (
           <div
             key={idx}
             style={{
               paddingLeft: 1,
-              width: `${100 / lightness.length}%`,
+              width: `${100 / activeLightness.length}%`,
               boxSizing: 'border-box',
             }}
           >
             <div
-              onClick={(evn) => handleClick(hslStr, evn)}
+              onClick={(evn) => handleClick(rgbaStr, evn)}
               style={{
-                backgroundColor: hslStr,
+                backgroundColor: rgbaStr,
                 height: 12,
                 cursor: 'pointer',
                 ...(checked

--- a/packages/color-slider/src/index.tsx
+++ b/packages/color-slider/src/index.tsx
@@ -22,18 +22,21 @@ const hsvaCheck = (color?: string | HsvaColor): HsvaColor => {
   return (typeof color === 'string' && validHex(color) ? hexToHsva(color) : color || {}) as HsvaColor;
 };
 
-const hsvaEqual = (c1: HsvaColor, c2: HsvaColor, lightnessArray?: number[]): boolean => {
-  // Check for exact match of all properties
-  const exactMatch = c1.h === c2.h && c1.s === c2.s && c1.v === c2.v && c1.a === c2.a;
+// Check if values are within specified units of each other
+const withinRange = (val1: number, val2: number, tolerance: number = 2): boolean => Math.abs(val1 - val2) <= tolerance;
 
-  // If there's an exact match, return true
+const hsvaEqual = (c1: HsvaColor, c2: HsvaColor, lightnessArray?: number[]): boolean => {
+  // Check for match within 2 units of all properties
+  const baseMatch = withinRange(c1.h, c2.h) && withinRange(c1.s, c2.s) && withinRange(c1.a, c2.a);
+  const exactMatch = baseMatch && withinRange(c1.v, c2.v);
+
+  // If there's a match within range, return true
   if (exactMatch) return true;
 
-  // If no exact match and a lightness array exists, check if the base
-  // properties match and value is within 1 unit of any lightness value
+  // If no exact match and a lightness array exists,
+  // check if value is within range of any of the lightness array values
   if (lightnessArray) {
-    const baseMatch = c1.h === c2.h && c1.s === c2.s && c1.a === c2.a;
-    return baseMatch && lightnessArray.some((lightness) => Math.abs(c2.v - lightness) <= 1);
+    return baseMatch && lightnessArray.some((lightness) => withinRange(c2.v, lightness));
   }
 
   return false;

--- a/packages/color-slider/src/index.tsx
+++ b/packages/color-slider/src/index.tsx
@@ -46,7 +46,10 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
     style,
     onChange,
     color,
-    customColorShades = [{ color: hexToHsva('#000000'), lightness: [14, 12, 10, 8, 6] }],
+    customColorShades = [
+      { color: '#000000', lightness: [50, 40, 30, 20, 10] },
+      { color: '#ffffff', lightness: [95, 90, 80, 70, 60] },
+    ],
     lightness = [80, 65, 50, 35, 20],
     ...other
   } = props;


### PR DESCRIPTION
The current implementation does not handle black or white colors. If you pass it black or white, you get red.
Furthermore, hsva to hsl conversion was distortion-prone, so I removed hsl altogether and replaced it with rgba. Now the color-slider reliably converts hsva to rgba for display, then back to hsva for the internal workings. This was necessary to deal with black and white.

Lastly, I added a customColorShades prop, such that you can define a custom lightness array for specific colors. In case you want a color to have certain lightness values displayed. For example, black and white (which by default are set on the prop).

Example usage: 
```typescript
import React, { useState } from 'react';
import Slider from '@uiw/react-color-slider';

export default function Demo() {
  const [hsva, setHsva] = useState({ h: 0, s: 0, v: 0, a: 1 });
  return (
    <Slider
      color={hsva}
      onChange={(color) => {
        setHsva({ ...hsva, ...color.hsv });
      }}
      customColorShades={[
        { color: '#000000', lightness: [50, 40, 30, 20, 10] },
        { color: '#ffffff', lightness: [95, 90, 80, 70, 60] },
      ]}
    />
  );
}
```

You can also use hsva (e.g. { h: 0, s: 0, v: 100, a: 1 }) for the customColorShades color instead of hex. I just used hex for convenience.

![Screenshot 2025-06-17 235234](https://github.com/user-attachments/assets/83311e21-7f6f-4650-8a4e-7db23a83b20a)
![Screenshot 2025-06-17 235847](https://github.com/user-attachments/assets/9740f86b-b352-4208-93b0-ec9439879610)