### PR TITLE
react-color-compact: Pass addonBefore and addonAfter props to react-compact

### DIFF
--- a/packages/color-compact/src/index.tsx
+++ b/packages/color-compact/src/index.tsx
@@ -135,7 +135,10 @@ const Compact = React.forwardRef<HTMLDivElement, CompactProps<React.MouseEvent<H
         addonBefore={addonBefore}
         addonAfter={addonAfter}
       />
-      <div style={{ display: 'flex', margin: '0 4px 3px 0' }}>
+      <div
+        className={[`${prefixCls}-input-wrapper`, className || ''].filter(Boolean).join(' ')}
+        style={{ display: 'flex', margin: '0 4px 3px 0' }}
+      >
         <EditableInput
           onChange={(evn, val) => handleHex(val, evn)}
           labelStyle={{ paddingRight: 5, marginTop: -1 }}


### PR DESCRIPTION
The swatch component (`react-color/packages/color-swatch`), which `react-color-compact` uses under the hood, has `addonBefore` and `addonAfter` props, allowing you to pass custom content to the component.

For some reason, they were excluded from the `react-color-compact` component.
So I added them back in.

Now you can do something like this:

```typescript
addonAfter={<ColorPickerCustom />}
```

(using tailwind:)

```typescript
export default function ColorPickerCustom() {
    return (
        <div tabIndex={0}
            className="bg-linear-to-br/decreasing from-violet-700 via-lime-300 to-violet-700"
            style={{
                borderRadius: '2px',
                height: '1.25rem',
                width: '1.25rem',
                display: 'flex',
                alignItems: 'center',
                justifyContent: 'center',
                cursor: 'pointer',
                margin: '2px',
                border: '1px solid var(--color-border)',
                position: 'relative',
                outline: 'none',
            }} />
    );
}
``` 

<img width="299" height="121" alt="Screenshot 2025-07-11 092410" src="https://github.com/user-attachments/assets/df45c0dc-7e3a-4e3d-9019-bb9921183cbc" />

I also added a className to the wrapper div around the editable input (prefixCls`-input-wrapper`, which defaults to `w-color-compact-input-wrapper`), so you can override the styles in your css. (By default the wrapper has a margin on it, so now you can change that.)