### PR TITLE
Change checkbox label to always show 'Show Alpha'

### DIFF
--- a/website/src/pages/colorful/index.tsx
+++ b/website/src/pages/colorful/index.tsx
@@ -18,7 +18,7 @@ function Example() {
       <div>
         <label>
           <input type="checkbox" checked={disableAlpha} onChange={(evn) => setDisableAlpha(evn.target.checked)} />
-          {disableAlpha ? 'Hide' : 'Show'} Alpha
+          Show Alpha
         </label>
       </div>
     </div>

--- a/website/src/pages/colorful/index.tsx
+++ b/website/src/pages/colorful/index.tsx
@@ -17,7 +17,7 @@ function Example() {
       />
       <div>
         <label>
-          <input type="checkbox" checked={disableAlpha} onChange={(evn) => setDisableAlpha(evn.target.checked)} />
+          <input type="checkbox" checked={!disableAlpha} onChange={(evn) => setDisableAlpha(evn.target.checked)} />
           Show Alpha
         </label>
       </div>


### PR DESCRIPTION
The current hide/show text doesnt make sense: a user clicks "Show alpha" to hide it, see screnshots

<img width="256" height="272" alt="Screenshot 2026-02-11 at 10 57 33 AM" src="https://github.com/user-attachments/assets/2f25bcb5-d9fb-430b-9a0a-4ef4d098fb26" />

<img width="273" height="301" alt="Screenshot 2026-02-11 at 10 57 28 AM" src="https://github.com/user-attachments/assets/955753ed-939a-4f3b-ac53-458e964ff5a2" />

It makes more sense to keep the text `Show Alpha` and have the user toggle that